### PR TITLE
Move neat-log to output and update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [terminal-link](https://github.com/sindresorhus/terminal-link) – Create clickable links in the terminal.
 - [jsome](https://github.com/Javascipt/Jsome) – Pretty format JSON on terminal.
 - [term-img](https://github.com/sindresorhus/term-img) – Display images in iTerm.
+- [neat-log](https://github.com/neat-log/neat-log) – Logger for stateful Command Line Applications.
 
 ## Framework
 
@@ -70,7 +71,6 @@
 </div>
 
 - ⭐[ink](https://github.com/vadimdemedes/ink) – React for interactive command-line apps.
-- [neat-log](https://github.com/neat-log/neat-log) – Stateful Command Line Applications.
 
 ## Helpful
 


### PR DESCRIPTION
This PR moves the neat-log entry from "Framework" to "Output" and updates it's description to be more accurate.