### PR TITLE
Add usql

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [pv](https://github.com/icetee/pv) - Monitoring the progress of data through a pipeline.
 - [share](https://github.com/marionebl/share-cli) - Quickly share files from your command line.
 - [spot](https://github.com/rauchg/spot) - Tiny search utility.
+- [usql](https://github.com/xo/usql) - Universal command-line interface for SQL databases.
 - [z](https://github.com/rupa/z) - The definity directory jumper.
 
 ## Bibliography


### PR DESCRIPTION
[usql](https://github.com/xo/usql/) is an universal command-line interface for SQL databases, heavily inspired and mostly compatible with `psql`.
* has the common features, like autocomplete, syntax highlight, pager support, variables that can be interpolated in queries, running scripts from files, saving output to files, exporting JSON and CSV
* has all output formats from `psql`
* has advanced features, like listing database schema objects, a `\copy` command to copy data across different databases, `\crossview` to present results in a pivot table
* is written in Go, which makes it easy to extend
* is distributed as fully static binaries, which makes it very portable
* supports most databases that have a Go driver, already including a few dozen different databases