### PR TITLE
Add zoxide under Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 - [share](https://github.com/marionebl/share-cli) - Quickly share files from your command line.
 - [spot](https://github.com/rauchg/spot) - Tiny search utility.
 - [z](https://github.com/rupa/z) - The definity directory jumper.
+- [zoxide](https://github.com/ajeetdsouza/zoxide) - A smarter cd command. Works on all major shells.
 
 ## Bibliography
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@
 - [pv](https://github.com/icetee/pv) - Monitoring the progress of data through a pipeline.
 - [share](https://github.com/marionebl/share-cli) - Quickly share files from your command line.
 - [spot](https://github.com/rauchg/spot) - Tiny search utility.
-- [z](https://github.com/rupa/z) - The definity directory jumper.
 - [zoxide](https://github.com/ajeetdsouza/zoxide) - A smarter cd command. Works on all major shells.
 
 ## Bibliography


### PR DESCRIPTION
zoxide is a smarter cd command that works on all major shells. It also runs on text editors like vim/emacs, and file explorers like nnn/ranger. 