### PR TITLE
Add supercli to Framework section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 
 ## Framework
 
+n- [supercli](https://github.com/javimosch/supercli) - Universal CLI runtime with 7,000+ plugins. Agent-native discovery, deterministic JSON output, MCP support.
 <div align="center">
   <br>
   <img src="https://github.com/vadimdemedes/ink/raw/master/media/demo.svg?sanitize=true">


### PR DESCRIPTION
Adds [supercli](https://github.com/javimosch/supercli) — universal CLI runtime with 7,000+ plugins. Agent-native discovery, deterministic JSON output, MCP support.

Fits the Framework section as it provides a universal capabilities runtime that wraps CLI tools behind a unified `ns resource action` interface.